### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     needs: [ verify ]
     if: needs.verify.outputs.new-release-published == 'true'
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - name: Set up node


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.