### PR TITLE
chore: enforce minimum dependency age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   esbuild: true
   lefthook: true
+
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

- Enforce a seven-day minimum release age for newly published dependencies.
- Add the package-manager metadata to `pnpm-workspace.yaml` without changing the lockfile.

## Verification

- Inspected the staged diff and confirmed only `pnpm-workspace.yaml` changed.
- Ran `git diff --check`.
- Per repository constraints, did not invoke pnpm, npm, Corepack, project scripts, tests, linters, formatters, builds, or validators.